### PR TITLE
Chapter Two return comments back

### DIFF
--- a/src/Chapter2.hs
+++ b/src/Chapter2.hs
@@ -337,10 +337,11 @@ from it!
 ghci> :l src/Chapter2.hs
 -}
 subList :: Int -> Int -> [a] -> [a]
-subList firstPoint secondPoint array =
-    if firstPoint < 0 || secondPoint < 0
-    then []
-    else take (secondPoint - firstPoint + 1) (drop firstPoint array)
+subList firstPoint secondPoint array
+    | firstPoint < 0 = []
+    | secondPoint < 0 = []
+    | firstPoint > secondPoint = []
+    | otherwise = take (secondPoint - firstPoint + 1) (drop firstPoint array)
 
 {- |
 =⚔️= Task 4
@@ -615,7 +616,7 @@ Implement a function that duplicates each element of the list
 -}
 duplicate :: [a] -> [a]
 duplicate [] = []
-duplicate (x:xs) = [x, x] ++ duplicate xs
+duplicate (x:xs) = x : x : duplicate xs
 
 
 {- |
@@ -633,8 +634,7 @@ Write a function that takes elements of a list only on even positions.
 takeEven :: [a] -> [a]
 takeEven [] = []
 takeEven [x] = [x]
-takeEven [x, _, xs] = [x, xs]
-takeEven (x:_:xs) = [x] ++ takeEven xs
+takeEven (x:_:xs) = x : takeEven xs
 
 {- |
 =🛡= Higher-order functions
@@ -741,7 +741,7 @@ value of the element itself
 🕯 HINT: Use combination of 'map' and 'replicate'
 -}
 smartReplicate :: [Int] -> [Int]
-smartReplicate l = concat (map (\a -> replicate a a) l)
+smartReplicate = concatMap (\a -> replicate a a)
 
 {- |
 =⚔️= Task 9
@@ -881,8 +881,11 @@ and reverses it.
   cheating!
 -}
 rewind :: [Int] -> [Int]
-rewind [] = []
-rewind (x:xs) = rewind xs ++ [x] 
+rewind = go []
+    where
+        go :: [Int] -> [Int] -> [Int]
+        go rew [] = rew
+        go rew (x:xs) = go (x : rew) xs
 
 
 {-

--- a/src/Chapter2.hs
+++ b/src/Chapter2.hs
@@ -755,7 +755,7 @@ the list with only those lists that contain a passed element.
 🕯 HINT: Use the 'elem' function to check whether an element belongs to a list
 -}
 contains :: Int -> [[Int]] -> [[Int]]
-contains x a = filter (elem x) a
+contains x = filter (elem x)
 
 
 {- |

--- a/src/Chapter2.hs
+++ b/src/Chapter2.hs
@@ -136,43 +136,43 @@ functions in GHCi and insert the corresponding resulting output below:
 
 List of booleans:
 >>> :t [True, False]
-
+[True, False] :: [Bool]
 
 String is a list of characters:
 >>> :t "some string"
-
+"some string" :: [Char]
 
 Empty list:
 >>> :t []
-
+[] :: [a]
 
 Append two lists:
 >>> :t (++)
-
+(++) :: [a] -> [a] -> [a]
 
 Prepend an element at the beginning of a list:
 >>> :t (:)
-
+(:) :: a -> [a] -> [a]
 
 Reverse a list:
 >>> :t reverse
-
+reverse :: [a] -> [a]
 
 Take first N elements of a list:
 >>> :t take
-
+take :: Int -> [a] -> [a]
 
 Create list from N same elements:
 >>> :t replicate
-
+replicate :: Int -> a -> [a]
 
 Split a string by line breaks:
 >>> :t lines
-
+lines :: String -> [String]
 
 Join a list of strings with line breaks:
 >>> :t unlines
-
+unlines :: [String] -> String
 
 -}
 
@@ -186,30 +186,31 @@ Evaluate the following expressions in GHCi and insert the answers. Try
 to guess first, what you will see.
 
 >>> [10, 2] ++ [3, 1, 5]
-
+[10,2,3,1,5]
 >>> [] ++ [1, 4]  -- [] is an empty list
-
+[1,4]
 >>> 3 : [1, 2]
-
+[3,1,2]
 >>> 4 : 2 : [5, 10]  -- prepend multiple elements
-
+[4,2,5,10]
 >>> [1 .. 10]  -- list ranges
-
+[1,2,3,4,5,6,7,8,9,10]
 >>> [10 .. 1]
-
+[]
 >>> [10, 9 .. 1]  -- backwards list with explicit step
-
+[10,9,8,7,6,5,4,3,2,1]
 >>> length [4, 10, 5]  -- list length
-
+3
 >>> replicate 5 True
-
+[True,True,True,True,True]
 >>> take 5 "Hello, World!"
-
+"Hello"
 >>> drop 5 "Hello, World!"
-
+", World!"
 >>> zip "abc" [1, 2, 3]  -- convert two lists to a single list of pairs
-
+[('a',1),('b',2),('c',3)]
 >>> words "Hello   Haskell     World!"  -- split the string into the list of words
+["Hello","Haskell","World!"]
 
 
 
@@ -336,7 +337,10 @@ from it!
 ghci> :l src/Chapter2.hs
 -}
 subList :: Int -> Int -> [a] -> [a]
-subList = error "subList: Not implemented!"
+subList firstPoint secondPoint array =
+    if firstPoint < 0 || secondPoint < 0
+    then []
+    else take (secondPoint - firstPoint + 1) (drop firstPoint array)
 
 {- |
 =⚔️= Task 4
@@ -348,8 +352,11 @@ Implement a function that returns only the first half of a given list.
 >>> firstHalf "bca"
 "b"
 -}
--- PUT THE FUNCTION TYPE IN HERE
-firstHalf l = error "firstHalf: Not implemented!"
+firstHalf :: [a] -> [a]
+firstHalf array = take (halfLength array) array
+    where
+        halfLength :: [a] -> Int
+        halfLength arr = div (length arr) 2
 
 
 {- |
@@ -500,7 +507,9 @@ True
 >>> isThird42 [42, 42, 0, 42]
 False
 -}
-isThird42 = error "isThird42: Not implemented!"
+isThird42 :: [Int] -> Bool
+isThird42 (_ : _ : 42 : _) = True
+isThird42 _ = False
 
 
 {- |
@@ -605,7 +614,8 @@ Implement a function that duplicates each element of the list
 
 -}
 duplicate :: [a] -> [a]
-duplicate = error "duplicate: Not implemented!"
+duplicate [] = []
+duplicate (x:xs) = [x, x] ++ duplicate xs
 
 
 {- |
@@ -620,7 +630,11 @@ Write a function that takes elements of a list only on even positions.
 >>> takeEven [2, 1, 3, 5, 4]
 [2,3,4]
 -}
-takeEven = error "takeEven: Not implemented!"
+takeEven :: [a] -> [a]
+takeEven [] = []
+takeEven [x] = [x]
+takeEven [x, _, xs] = [x, xs]
+takeEven (x:_:xs) = [x] ++ takeEven xs
 
 {- |
 =🛡= Higher-order functions
@@ -727,7 +741,7 @@ value of the element itself
 🕯 HINT: Use combination of 'map' and 'replicate'
 -}
 smartReplicate :: [Int] -> [Int]
-smartReplicate l = error "smartReplicate: Not implemented!"
+smartReplicate l = concat (map (\a -> replicate a a) l)
 
 {- |
 =⚔️= Task 9
@@ -740,7 +754,8 @@ the list with only those lists that contain a passed element.
 
 🕯 HINT: Use the 'elem' function to check whether an element belongs to a list
 -}
-contains = error "contains: Not implemented!"
+contains :: Int -> [[Int]] -> [[Int]]
+contains x a = filter (elem x) a
 
 
 {- |
@@ -780,13 +795,15 @@ Let's now try to eta-reduce some of the functions and ensure that we
 mastered the skill of eta-reducing.
 -}
 divideTenBy :: Int -> Int
-divideTenBy x = div 10 x
+divideTenBy = div 10
 
 -- TODO: type ;)
-listElementsLessThan x l = filter (< x) l
+listElementsLessThan :: Int -> [Int] -> [Int]
+listElementsLessThan x = filter (< x)
 
 -- Can you eta-reduce this one???
-pairMul xs ys = zipWith (*) xs ys
+pairMul :: [Int] -> [Int] -> [Int]
+pairMul = zipWith (*)
 
 {- |
 =🛡= Lazy evaluation
@@ -841,7 +858,13 @@ list.
 
 🕯 HINT: Use the 'cycle' function
 -}
-rotate = error "rotate: Not implemented!"
+rotate :: Int -> [Int] -> [Int]
+rotate _ [] = []
+rotate x y =
+    if x < 0
+    then []
+    else take (length y) (drop x (cycle y))
+
 
 {- |
 =💣= Task 12*
@@ -857,7 +880,9 @@ and reverses it.
   function, but in this task, you need to implement it manually. No
   cheating!
 -}
-rewind = error "rewind: Not Implemented!"
+rewind :: [Int] -> [Int]
+rewind [] = []
+rewind (x:xs) = rewind xs ++ [x] 
 
 
 {-


### PR DESCRIPTION
### Solutions for Chapter 2

There're some questions:
- Why I cannot do contains function like this?
```
contains :: Int -> [[a]] -> [[a]]
contains x a = filter (elem x) a
```
instead of 
```
contains :: Int -> [[Int]] -> [[Int]]
contains x a = filter (elem x) a
```
- And why only `[10 .. 1]` in this cases produce empty list?
```
>>> [1 .. 10]  -- list ranges
[1,2,3,4,5,6,7,8,9,10]
>>> [10 .. 1]
[]
>>> [10, 9 .. 1]  -- backwards list with explicit step
[10,9,8,7,6,5,4,3,2,1]
```

You implemented this haskell tutorial so great, thank you very much ❤️ 

cc @vrom911 @chshersh
